### PR TITLE
Fixed an issue where the server would sometimes return a 500 status code instead of a 403 one

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -16,7 +16,7 @@ var internals = {};
  */
 exports.checkRoles = function(user, role, hierarchy) {
 
-	if (!internals.isGranted(user.role, role, hierarchy)) {
+	if ((!user) || (!internals.isGranted(user.role, role, hierarchy))) {
 		return Boom.forbidden('Unauthorized');
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ exports.register = function (server, options, next) {
  */
 exports.register.attributes = {
 	pkg: require('../package.json')
-}
+};
 
 
 /**
@@ -146,14 +146,7 @@ internals.onPostAuth = function(request, reply) {
 			Q
 				// Checks roles
 				.fcall(function () {
-
 					if (params.role || params.roles) {
-
-						// If request.auth.credentials
-						if(!user) {
-							throw new Error('request.auth.credentials does not exist');
-						}
-						
 						var err = ACL.checkRoles(user, params.role || params.roles, roleHierarchy);
 						if (err) {
 							throw err;
@@ -183,7 +176,7 @@ internals.onPostAuth = function(request, reply) {
 							throw new Error('Entity is required');
 						}
 
-						return ACL.validateEntityAcl(user, params.role, entity, params['validateAclMethod'], params);
+						return ACL.validateEntityAcl(user, params.role, entity, params.validateAclMethod, params);
 					}
 					return null;
 				})


### PR DESCRIPTION
Under certain circumstances, the server would throw a `TypeError`, thus generating a 500 response instead of a 403 (or 404) one. This fixes the problem.

In particular, when the plugin is enabled by default on all routes, all non-existent routes would throw the following error
```
TypeError: Cannot read property 'role' of null
at Object.exports.checkRoles ([...]\hapi-authorization\lib\acl.js:19:31)
[...]
```
and result in a 500 status code in the response
```
{
    "statusCode": 500,
    "error": "Internal Server Error",
    "message": "An internal server error occurred"
}
```
instead of the intended 403 or 404 one.
I simply added one more check to make sure the `user` object exists and is non-empty before trying to access its members.
I chose to leave the response status code as 403 as not disclosing existing routes helps maintain higher security.

I originally tested this against the NPM version of the package, which is slightly different from the Git version, so I had to edit some more code in order to make it work as intended.
I also fixed a couple of linting errors on my way.