### PR TITLE
Added 'request' parameter to ACL.fetchEntity function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 You can use this plugin to add ACL and protect your routes. you can configure required roles and allow access to certain endpoints only to specific users.
 
 ### Support
-Hapi >= 6 < 8	- Use version 1.x  
+Hapi >= 6 < 8	- Use version 1.x
 Hapi >= 8			- Use version 2.x
 
 # Usage
@@ -199,7 +199,7 @@ You must define your auth strategy before defining your routes, otherwise the ro
 ## Route config of supported parameters:
 * `role` - `String`: enforces that only users that have this role can access the route
 * `roles` - `Array`: enforces that only users that have these roles can access the route
-* `aclQuery` - `Function`: fetches an entity using the provided query, it allows the plugin to verify that the authenticated user has permissions to access this entity. the function signature should be `function(parameter, cb)`.
+* `aclQuery` - `Function`: fetches an entity using the provided query, it allows the plugin to verify that the authenticated user has permissions to access this entity. the function signature should be `function(parameter, request, cb)`.
 * `aclQueryParam` - `String`: The parameter key that will be used to fetch the entity. default: 'id'
 * `paramSource` - `String`: The source of the acl parameter, allowed values: payload, params, query.
 * `validateEntityAcl` - `Boolean`: Should the plugin validate if the user has access to the entity. if true, validateAclMethod is required.

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -84,10 +84,10 @@ internals.isGranted = function(userRole, requiredRole, hierarchy) {
  * @param request - The originating request
  * @param cb - function(err, entity) that will be used to notify the caller about the result of the query
  */
-exports.fetchEntity = function(query, param, cb) {
+exports.fetchEntity = function(query, param, request, cb) {
 
 	var def = Q.defer();
-	query(param, function(err, entity) {
+	query(param, request, function(err, entity) {
 
 		if (err) {
 			return def.reject(Boom.badRequest('Bad Request', err));

--- a/test/index.js
+++ b/test/index.js
@@ -801,7 +801,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, {id: '1', name: 'Asaf'});
 					}}},
 					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
@@ -824,7 +824,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -846,7 +846,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(new Error("Boomy"), null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -894,7 +894,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, null);
 						}
 					}},
@@ -920,7 +920,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
 						}
 					}},
@@ -946,7 +946,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
 						}
 					}},
@@ -972,7 +972,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
 						}
 					}},
@@ -1003,7 +1003,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello'});
 						}
 					}},
@@ -1029,7 +1029,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -1055,7 +1055,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -1082,7 +1082,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -1109,7 +1109,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {creator: '1', name: 'Hello'});
 						}
 					}},
@@ -1579,7 +1579,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, {id: '1', name: 'Asaf'});
 					}}},
 					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
@@ -1602,7 +1602,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -1624,7 +1624,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(new Error("Boomy"), null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -1672,7 +1672,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, null);
 						}
 					}},
@@ -1698,7 +1698,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
 						}
 					}},
@@ -1724,7 +1724,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
 						}
 					}},
@@ -1750,7 +1750,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
 						}
 					}},
@@ -1781,7 +1781,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello'});
 						}
 					}},
@@ -1807,7 +1807,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -1833,7 +1833,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -1860,7 +1860,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -1887,7 +1887,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {creator: '1', name: 'Hello'});
 						}
 					}},
@@ -2359,7 +2359,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, {id: '1', name: 'Asaf'});
 					}}},
 					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
@@ -2382,7 +2382,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -2404,7 +2404,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(new Error("Boomy"), null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -2453,7 +2453,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, null);
 						}
 					}},
@@ -2479,7 +2479,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
 						}
 					}},
@@ -2505,7 +2505,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
 						}
 					}},
@@ -2531,7 +2531,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
 						}
 					}},
@@ -2563,7 +2563,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello'});
 						}
 					}},
@@ -2589,7 +2589,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -2615,7 +2615,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -2642,7 +2642,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -2669,7 +2669,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {creator: '1', name: 'Hello'});
 						}
 					}},
@@ -3137,7 +3137,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, {id: '1', name: 'Asaf'});
 					}}},
 					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
@@ -3160,7 +3160,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -3182,7 +3182,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(new Error("Boomy"), null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -3230,7 +3230,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, null);
 						}
 					}},
@@ -3256,7 +3256,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
 						}
 					}},
@@ -3282,7 +3282,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
 						}
 					}},
@@ -3308,7 +3308,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
 						}
 					}},
@@ -3340,7 +3340,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello'});
 						}
 					}},
@@ -3366,7 +3366,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -3392,7 +3392,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -3419,7 +3419,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -3446,7 +3446,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {creator: '1', name: 'Hello'});
 						}
 					}},
@@ -3918,7 +3918,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, {id: '1', name: 'Asaf'});
 					}}},
 					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
@@ -3941,7 +3941,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(null, null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -3963,7 +3963,7 @@ describe('hapi-authorization', function() {
 
 				server.route({ method: 'GET', path: '/', config: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, cb) {
+					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
 						cb(new Error("Boomy"), null);
 					}}},
 					handler: function (request, reply) { reply("Oops");}
@@ -4011,7 +4011,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, null);
 						}
 					}},
@@ -4037,7 +4037,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
 						}
 					}},
@@ -4063,7 +4063,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
 						}
 					}},
@@ -4089,7 +4089,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
 						}
 					}},
@@ -4121,7 +4121,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {id: id, name: 'Hello'});
 						}
 					}},
@@ -4147,7 +4147,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -4173,7 +4173,7 @@ describe('hapi-authorization', function() {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -4200,7 +4200,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {_user: '1', name: 'Hello'});
 						}
 					}},
@@ -4227,7 +4227,7 @@ describe('hapi-authorization', function() {
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, cb) {
+						aclQuery: function(id, request, cb) {
 							cb(null, {creator: '1', name: 'Hello'});
 						}
 					}},


### PR DESCRIPTION
Function documentation in acl.js indicates presence of the parameter, but is not implemented.

Access to the `request` object would be very helpful addition for a custom `aclQuery()` function when fetching an entity.