### PR TITLE
Hapi 11: TypeError: server.after is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,11 @@ exports.register = function (server, options, next) {
 		});
 
 		// Validate the server options on the routes
-		server.after(internals.validateRoutes);
+		if (server.after) { // Support for hapi < 11
+			server.after(internals.validateRoutes);
+		} else {
+			server.ext('onPreStart', internals.validateRoutes);
+		}
 		//server.ext('onPreAuth', internals.onPreAuth);
 		server.ext('onPostAuth', internals.onPostAuth);
 


### PR DESCRIPTION
This PR fixes the error with hapi 11.
Hapi 11 removed the server.after method and added a new event:
https://github.com/hapijs/hapi/issues/2814

This fix will allow to support the old version of hapi if server.after is defined, otherwise, it will use the new event.
