### PR TITLE
Add test for issue causing the response to remain open and never finish

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,15 +117,19 @@ internals.validateRoutes = function(server, next) {
  */
 internals.onPreHandler = function(request, reply) {
 
-	try {
-
 		// Ignore OPTIONS requests
 		if(request.route.method === 'options') {
 			return reply.continue();
 		}
 
-		// Check if the current route is hapi-authorization enabled
-		var params = internals.getRouteParams(request);
+		var params;
+		try{
+			// Check if the current route is hapi-authorization enabled
+			params = internals.getRouteParams(request);
+		}
+		catch(err){
+			return reply(Boom.badRequest(err.message));
+		}
 
 		// if hapi-authorization is enabled, get the user
 		if (params) {
@@ -194,10 +198,7 @@ internals.onPreHandler = function(request, reply) {
 		} else {
 			reply.continue();
 		}
-	}
-	catch (err) {
-		reply(Boom.badRequest(err.message));
-	}};
+};
 
 /**
  * Returns the plugin params for the current request

--- a/test/index.js
+++ b/test/index.js
@@ -24,18 +24,17 @@ describe('hapi-authorization', function() {
 	it('does not interfere with handlers throwing exceptions', function(done) {
 		var server = new Hapi.Server();
 		server.connection();
-		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-
 		server.route({ method: 'GET', path: '/', config: {
-			auth: 'default',
-			handler: function (request, reply) {throw new Error("ouch");}
+			handler: function (request, reply) {throw new Error("uncaught exception test");}
 		}});
 		server.register(plugin, {}, function(err) {
-			server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-				internals.asyncCheck(function() {
-					expect(res.statusCode).to.equal(500);
-				}, done);
+			server.start(function(err) {
+				server.inject({method: 'GET', url: '/'}, function(res) {
+					internals.asyncCheck(function() {
+						expect(res.statusCode).to.equal(500);
+						server.stop(NOOP);
+					}, done);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Hi!

I've found an issue after upgrading to hapi-authorization 3.0.0. If you just throw an exception in a Hapi handler, then the response stays open and hangs forever.

I managed to create a test reproducing the problem here, to me it looks like the solution would be to avoid the global try/catch in `onPreHandler` or catching the specific errors thrown by hapi-authorization itself and not every exception. But not sure if that would be the best solution, probably you know better than me. Thanks for your help.

