### PR TITLE
Added the Boom error recognize for ACL.fetchEntity

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -89,7 +89,9 @@ exports.fetchEntity = function(query, param, request, cb) {
 	var def = Q.defer();
 	query(param, request, function(err, entity) {
 
-		if (err) {
+		if (err && err.isBoom) {
+			return def.reject(err);
+		} else if (err) {
 			return def.reject(Boom.badRequest('Bad Request', err));
 		}
 		else if (!entity) {


### PR DESCRIPTION
Previously the aclQuery function were responding with BadRequest() for all errors,
Now first will be checked if the error is a Boom error (and returned as it is).