### PR TITLE
Support either user.credentials.role or .roles

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -16,7 +16,7 @@ var internals = {};
  */
 exports.checkRoles = function(user, role, hierarchy) {
 
-	if ((!user) || (!internals.isGranted(user.role, role, hierarchy))) {
+	if ((!user) || (!internals.isGranted(user.role || user.roles, role, hierarchy))) {
 		return Boom.forbidden('Unauthorized');
 	}
 


### PR DESCRIPTION
Since either `role` or `roles` are supported in the config, might as well support it directly on the credentials. Plus, it's perfect for couchdb users :-)
