### PR TITLE
Support for Hapi v17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 .idea
 lib-cov
 coverage.html
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 sudo: false
 
 node_js:
-  - '5'
-  - '4.2.0'
-  - '4'
+  - 8
+  - 10
+  - "node"
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hapi-authorization
 
+*hapi-authorization 4 only supports hapi 17+ for hapi 16 please use hapi-authorization 3*
+
 > ACL support for hapijs apps
 
 [![npm version][npm-badge]][npm-url]
@@ -14,6 +16,7 @@ You can use this plugin to add ACL and protect your routes. you can configure re
 - `Hapi >= 6 < 8`   - Use version `1.x`
 - `Hapi >= 8 < 10`  - Use version `2.x`
 - `Hapi >= 10`      - Use version `3.x`
+- `Hapi >= 17`      - Use version `4.x`
 
 # Usage
 
@@ -30,18 +33,17 @@ Example:
 ```js
 var plugins = [
 	{
-		register: require('hapi-auth-basic')
+		plugin: require('hapi-auth-basic')
 	},
 	{
-		register: require('hapi-authorization')
+		plugin: require('hapi-authorization')
 		options: {
 		  roles: false	// By setting to false, you are not using an authorization hierarchy and you do not need to specify all the potential roles here
 		}
 	}
 ];
 
-server.register(plugins, function(err) {
-...
+await server.register(plugins);
 ```
 
 ## Using hapi-authorization with custom roles
@@ -50,18 +52,17 @@ Example:
 ```js
 var plugins = [
 	{
-		register: require('hapi-auth-basic')
+		plugin: require('hapi-auth-basic')
 	},
 	{
-		register: require('hapi-authorization'),
+		plugin: require('hapi-authorization'),
 		options: {
 			roles: ['OWNER', 'MANAGER', 'EMPLOYEE']	// Can also reference a function which returns an array of roles
 		}
 	}
 ];
 
-server.register(plugins, function(err) {
-...
+await server.register(plugins);
 ```
 
 #### Whitelist Routes That Require Authorization
@@ -92,8 +93,7 @@ If you want all routes to require authorization except for the ones you specify 
 Example:
 
 ```js
-var server = new Hapi.server();
-server.connection({
+var server = new Hapi.server({
 	routes: {
 		plugins: {
 			hapiAuthorization: { roles: ['ADMIN'] }
@@ -129,7 +129,6 @@ var modules = require('./modules');
 
 // Instantiate the server
 var server = new Hapi.Server();
-server.connection();
 
 /**
  * The hapijs plugins that we want to use and their configs
@@ -154,7 +153,8 @@ var validate = function(username, password, callback) {
 /**
  * Setup the server with plugins
  */
-server.register(plugins, function(err) {
+await server.register(plugins);
+server.start().then(err -> {
 
   // If there is an error on server startup
   if(err) {

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 [![Coverage Status][coveralls-badge]][coveralls-url]
 [![Dev Dependencies][david-badge]][david-url]
 
-
 You can use this plugin to add ACL and protect your routes. you can configure required roles and allow access to certain endpoints only to specific users.
 
 ### Support
+
 - `Hapi >= 6 < 8`   - Use version `1.x`
 - `Hapi >= 8 < 10`  - Use version `2.x`
 - `Hapi >= 10`      - Use version `3.x`
@@ -117,7 +117,6 @@ server.route({ method: 'GET', path: '/', options: {
   handler: (request, h) => { return "Great!"; }
 }});
 ```
-
 
 **Note:** Every route that uses hapiAuthorization must be protected by an authentication schema either via `auth.strategy.default('someAuthStrategy')` or by specifying the auth on the route itself.
 

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -1,6 +1,5 @@
 // External modules
 var Boom	= require('boom');
-var Q			= require('q');
 var _			= require('underscore');
 
 // Declare of internals
@@ -84,26 +83,26 @@ internals.isGranted = function(userRole, requiredRole, hierarchy) {
  * @param request - The originating request
  * @param cb - function(err, entity) that will be used to notify the caller about the result of the query
  */
-exports.fetchEntity = function(query, param, request, cb) {
+exports.fetchEntity = (query, param, request, cb) => {
 
-	var def = Q.defer();
-	query(param, request, function(err, entity) {
+	return new Promise((resolve, reject) => {
+    return query(param, request, function(err, entity) {
 
-		if (err && err.isBoom) {
-			return def.reject(err);
-		} else if (err) {
-			return def.reject(Boom.badRequest('Bad Request', err));
-		}
-		else if (!entity) {
-			return def.reject(Boom.notFound());
-		}
-		else {
-			def.resolve(entity);
-		}
-	});
-
-	return def.promise;
+      if (err && err.isBoom) {
+        return reject(err);
+      } else if (err) {
+        return reject(Boom.badRequest('Bad Request', err));
+      }
+      else if (!entity) {
+        return reject(Boom.notFound());
+      }
+      else {
+        resolve(entity);
+      }
+    });
+  });
 };
+
 
 /**
  * Verifies that the user has permission to access the wanted entity.
@@ -113,43 +112,44 @@ exports.fetchEntity = function(query, param, request, cb) {
  * @param entity - Verify if the authenticated user has "role" grants and can access this entity
  * @param validator - The method that will be used to verify if the user has permissions, this method should be used on the provided entity.
  * @param options - additional options
- * @returns {promise|*|Q.promise}
+ * @returns {promise|*|Promise}
  */
 exports.validateEntityAcl = function(user, role, entity, validator, options) {
 
-	var def = Q.defer();
+	return new Promise((resolve, reject) => {
+    
 
-	if (!entity) {
-		def.reject(new Error('validateUserACL must run after fetchACLEntity'));
-	} else if (!user) {
-		def.reject(new Error('User is required, please make sure this method requires authentication'));
-	} else {
+    if (!entity) {
+      reject(new Error('validateUserACL must run after fetchACLEntity'));
+    } else if (!user) {
+      reject(new Error('User is required, please make sure this method requires authentication'));
+    } else {
 
-		if (validator) {
+      if (validator) {
 
-			entity[validator](user, role, function(err, isValid) {
+        entity[validator](user, role, function(err, isValid) {
 
-				if (err) {
-					def.reject(new Error(err));
-				} else if (!isValid) {	// Not granted
-					def.reject(Boom.forbidden('Unauthorized'));
-				} else {	// Valid
-					def.resolve(isValid);
-				}
-			});
-		} else {
-			// Use the default validator
-			var isValid = internals.defaultEntityAclValidator(user, role, entity, options);
+          if (err) {
+            reject(new Error(err));
+          } else if (!isValid) {	// Not granted
+            reject(Boom.forbidden('Unauthorized'));
+          } else {	// Valid
+            resolve(isValid);
+          }
+        });
+      } else {
+        // Use the default validator
+        var isValid = internals.defaultEntityAclValidator(user, role, entity, options);
 
-			if (isValid) {
-				def.resolve(isValid);
-			} else {
-				def.reject(Boom.forbidden('Unauthorized'));
-			}
-		}
-	}
+        if (isValid) {
+          resolve(isValid);
+        } else {
+          reject(Boom.forbidden('Unauthorized'));
+        }
+      }
+    }
 
-	return def.promise;
+  });
 };
 
 /**

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -1,9 +1,9 @@
 // External modules
-var Boom	= require('boom');
-var _			= require('underscore');
+const Boom	= require('boom');
+const _			= require('underscore');
 
 // Declare of internals
-var internals = {};
+const internals = {};
 
 
 /**
@@ -31,11 +31,11 @@ exports.checkRoles = function(user, role, hierarchy) {
  */
 internals.isGranted = function(userRole, requiredRole, hierarchy) {
 
-	var userRoles = null;
+	let userRoles = null;
 
 	// If we're using a hierarchy, get all the possible roles
 	if(hierarchy) {
-		var index = hierarchy.indexOf(userRole);	// Get the index of userRole in the hierarchy
+    const index = hierarchy.indexOf(userRole);	// Get the index of userRole in the hierarchy
 
 		// If the user's role is not any of the possible roles
 		if (index === -1) {
@@ -81,26 +81,22 @@ internals.isGranted = function(userRole, requiredRole, hierarchy) {
  * @param query - function(id, cb) that returns the entity to the callback.
  * @param param - The "id" parameter that need to be provided for to the query
  * @param request - The originating request
- * @param cb - function(err, entity) that will be used to notify the caller about the result of the query
+ * @return wanted ACL entity
  */
-exports.fetchEntity = (query, param, request, cb) => {
-
-	return new Promise((resolve, reject) => {
-    return query(param, request, function(err, entity) {
-
-      if (err && err.isBoom) {
-        return reject(err);
-      } else if (err) {
-        return reject(Boom.badRequest('Bad Request', err));
-      }
-      else if (!entity) {
-        return reject(Boom.notFound());
-      }
-      else {
-        resolve(entity);
-      }
-    });
-  });
+exports.fetchEntity = async (query, param, request) => {
+  try {
+    const entity = await query(param, request);
+    if (!entity) {
+      throw Boom.notFound();
+    }
+    return entity;
+  } catch (err) {
+    if (err.isBoom) {
+      throw err;
+    } else if (err) {
+      throw Boom.badRequest('Bad Request', err);
+    }
+  }
 };
 
 
@@ -112,44 +108,41 @@ exports.fetchEntity = (query, param, request, cb) => {
  * @param entity - Verify if the authenticated user has "role" grants and can access this entity
  * @param validator - The method that will be used to verify if the user has permissions, this method should be used on the provided entity.
  * @param options - additional options
- * @returns {promise|*|Promise}
+ * @returns {boolean} Validation check result
  */
-exports.validateEntityAcl = function(user, role, entity, validator, options) {
+exports.validateEntityAcl = async (user, role, entity, validator, options) => {
+  if (!entity) {
+    throw new Error('validateUserACL must run after fetchACLEntity');
+  } else if (!user) {
+    throw new Error('User is required, please make sure this method requires authentication');
+  } else {
+    if (validator) {
 
-	return new Promise((resolve, reject) => {
-    
+      try {
+        const isValid = await entity[validator](user, role);
 
-    if (!entity) {
-      reject(new Error('validateUserACL must run after fetchACLEntity'));
-    } else if (!user) {
-      reject(new Error('User is required, please make sure this method requires authentication'));
-    } else {
-
-      if (validator) {
-
-        entity[validator](user, role, function(err, isValid) {
-
-          if (err) {
-            reject(new Error(err));
-          } else if (!isValid) {	// Not granted
-            reject(Boom.forbidden('Unauthorized'));
-          } else {	// Valid
-            resolve(isValid);
-          }
-        });
-      } else {
-        // Use the default validator
-        var isValid = internals.defaultEntityAclValidator(user, role, entity, options);
-
-        if (isValid) {
-          resolve(isValid);
+        if (!isValid) {	// Not granted
+          throw Boom.forbidden('Unauthorized');
+        } else {	// Valid
+          return isValid;
+        }
+      } catch (err) {
+        if (err.isBoom) {
+          throw err;
         } else {
-          reject(Boom.forbidden('Unauthorized'));
+          throw new Error(err);
         }
       }
+    } else {
+      // Use the default validator
+      const isValid = internals.defaultEntityAclValidator(user, role, entity, options);
+      if (isValid) {
+        return isValid;
+      } else {
+        throw Boom.forbidden('Unauthorized');
+      }
     }
-
-  });
+  }
 };
 
 /**
@@ -158,6 +151,7 @@ exports.validateEntityAcl = function(user, role, entity, validator, options) {
  * @param user
  * @param role
  * @param entity
+ * @param options
  * @returns {*|string|boolean}
  */
 internals.defaultEntityAclValidator = function(user, role, entity, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,11 +20,10 @@ const internals = {
 /**
  * Registers the plugin
  *
- * @param plugin
+ * @param server
  * @param options
- * @param next
  */
-const register = (server, options, next) => {
+const register = (server, options) => {
 
   // Validate the options passed into the plugin
   Schema.assert('plugin', options, 'Invalid settings');
@@ -54,141 +53,125 @@ exports.plugin = {
   version: require('../package.json').version,
   multiple: true,
   pkg: require('../package.json')
-}
+};
 
 
 /**
  * Runs on server start and validates that every route that has hapi-authorization params is valid
  *
  * @param server
- * @param next
  */
 internals.validateRoutes = (server) => {
 
-  // Loop through each connection in the server
-  console.log(server.connections)
-  server.connections.forEach((connection) => {
+	const routes = server.table();
 
-    const routes = (connection.routingTable) ? connection.routingTable() : connection.table();
+	// Loop through each route
+	routes.forEach((route) => {
 
-    // Loop through each route
-    routes.forEach((route) => {
+		const hapiAuthorizationParams = route.settings.plugins[pluginName] ? route.settings.plugins[pluginName] : false;
 
-      const hapiAuthorizationParams = route.settings.plugins[pluginName] ? route.settings.plugins[pluginName] : false;
+		// If there are hapi-authorization params and are not disabled by using "false", validate em
+		if (hapiAuthorizationParams !== false) {
 
-      // If there are hapi-authorization params and are not disabled by using "false", validate em
-      if (hapiAuthorizationParams !== false) {
+			// If there is a default auth
+			if (server.auth.settings.default) {
 
-        // If there is a default auth
-        if(connection.auth.settings.default) {
+				// If there is also an auth on the route, make sure it's not false or null
+				if (route.settings.auth !== undefined) {
 
-          // If there is also an auth on the route, make sure it's not false or null
-          if(route.settings.auth !== undefined) {
+					// Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
+					Hoek.assert(route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
+				}
+			}
+			// Else there is no default auth set, so validate each route's auth
+			else {
+				// Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
+				Hoek.assert(route.settings.auth && route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
+			}
 
-            // Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
-            Hoek.assert(route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
-          }
-        }
-        // Else there is no default auth set, so validate each route's auth
-        else {
-          // Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
-          Hoek.assert(route.settings.auth && route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
-        }
-
-        Schema.assert('route', hapiAuthorizationParams, 'Invalid settings');
-      }
-    });
-  });
+			Schema.assert('route', hapiAuthorizationParams, 'Invalid settings');
+		}
+	});
 };
 
 /**
  * Checks if hapi-authorization is active for the current route and execute the necessary steps accordingly.
  *
  * @param request
- * @param reply
+ * @param h
  */
-internals.onPreHandler = (request, reply) => {
+internals.onPreHandler = async (request, h) => {
 
-		// Ignore OPTIONS requests
-		if (request.route.method === 'options') {
-			return reply.continue();
-		}
+  // Ignore OPTIONS requests
+  if (request.route.method === 'options') {
+    return h.continue;
+  }
 
-		let params;
-		try {
-			// Check if the current route is hapi-authorization enabled
-			params = internals.getRouteParams(request);
-		}
-		catch(err){
-			return reply(Boom.badRequest(err.message));
-		}
+  let params;
+  try {
+    // Check if the current route is hapi-authorization enabled
+    params = internals.getRouteParams(request);
+  }
+  catch (err) {
+    return Boom.badRequest(err.message);
+  }
 
-		// if hapi-authorization is enabled, get the user
-		if (params) {
+  // if hapi-authorization is enabled, get the user
+  if (params) {
 
-			const user = request.auth.credentials;
+    const user = request.auth.credentials;
 
-			if (!request.plugins[pluginName]) {
-				request.plugins[pluginName] = {};
-			}
+    if (!request.plugins[pluginName]) {
+      request.plugins[pluginName] = {};
+    }
 
-			const roleHierarchy = null;
+    let roleHierarchy = null;
 
-			// If we're not using hierarchy
-			if(this.config.hierarchy === true) {
-				// this.config comes from plugin.bind
-				roleHierarchy = this.config.roleHierarchy;
-			} else {
-				roleHierarchy = false;
-			}
+    // If we're not using hierarchy
+    if (!!this.config && this.config.hierarchy === true) {
+      // this.config comes from plugin.bind
+      roleHierarchy = this.config.roleHierarchy;
+    } else {
+      roleHierarchy = false;
+    }
 
-				// Checks roles
-				Promise.resolve(() => { 
-					if (params.role || params.roles) {
-						const err = ACL.checkRoles(user, params.role || params.roles, roleHierarchy);
-						if (err) {
-							throw err;
-						}
-					}
-					return true;
-				})
-				// Fetches acl entities
-				.then(() => {
-					if (params.aclQuery) {
-						const parameter = request[params.paramSource][params.aclQueryParam];
-						return ACL.fetchEntity(params.aclQuery, parameter, request);
-					}
-					return null;
-				})
-				// Store the entity
-				.then(function(entity) {
-					if (entity) {
-						request.plugins[pluginName].entity = entity;
-						return entity;
-					}
-				})
-				// Validate the ACL settings
-				.then(function(entity) {
-					if (params.validateEntityAcl) {
-						if (!entity) {
-							throw new Error('Entity is required');
-						}
+    try {
+      // Checks roles
+      if (params.role || params.roles) {
+        const err = ACL.checkRoles(user, params.role || params.roles, roleHierarchy);
+        if (err) {
+          throw err;
+        }
+      }
 
-						return ACL.validateEntityAcl(user, params.role, entity, params.validateAclMethod, params);
-					}
-					return null;
-				})
-				.then(function () {
-					reply.continue();
-				})
-				// Handles errors
-				.catch(function (err) {
-					reply(err);
-				});
+      // Fetches acl entities
+      let entity = null;
+      if (params.aclQuery) {
+        const parameter = request[params.paramSource][params.aclQueryParam];
+        entity          = await ACL.fetchEntity(params.aclQuery, parameter, request);
+      }
 
-		} else {
-			reply.continue();
-		}
+      // Store the entity
+      if (entity) {
+        request.plugins[pluginName].entity = entity;
+      }
+      // Validate the ACL settings
+
+      if (params.validateEntityAcl) {
+        if (!entity) {
+          return new Error('Entity is required');
+        }
+
+        await ACL.validateEntityAcl(user, params.role, entity, params.validateAclMethod, params);
+      }
+      return h.continue;
+      // Handles errors
+    } catch (err) {
+      return err;
+    }
+  } else {
+    return h.continue;
+  }
 };
 
 /**
@@ -197,7 +180,7 @@ internals.onPreHandler = (request, reply) => {
  * @param request
  * @returns {*}
  */
-internals.getRouteParams = function(request) {
+internals.getRouteParams = (request) => {
 
 	if (request.route.settings.plugins[pluginName]) {
 		const params = request.route.settings.plugins[pluginName];

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ internals.validateRoutes = (server) => {
  * Checks if hapi-authorization is active for the current route and execute the necessary steps accordingly.
  *
  * @param request
- * @param h
+ * @param h Hapi Reponse Toolkit https://hapijs.com/api#response-toolkit
  */
 internals.onPreHandler = async (request, h) => {
 
@@ -162,7 +162,7 @@ internals.onPreHandler = async (request, h) => {
           return new Error('Entity is required');
         }
 
-        await ACL.validateEntityAcl(user, params.role, entity, params.validateAclMethod, params);
+        await ACL.validateEntityAcl(user, params.role || params.roles, entity, params.validateAclMethod, params);
       }
       return h.continue;
       // Handles errors

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,29 +26,23 @@ const internals = {
  */
 const register = (server, options, next) => {
 
-	try {
-		// Validate the options passed into the plugin
-		Schema.assert('plugin', options, 'Invalid settings');
+  // Validate the options passed into the plugin
+  Schema.assert('plugin', options, 'Invalid settings');
 
-		const settings = Hoek.applyToDefaults(internals.defaults, options || {});
+  const settings = Hoek.applyToDefaults(internals.defaults, options || {});
 
-		server.bind({
-			config: settings
-		});
+  server.bind({
+    config: settings
+  });
 
-		// Validate the server options on the routes
-		if (server.after) { // Support for hapi < 11
-			server.after(internals.validateRoutes);
-		} else {
-			server.ext('onPreStart', internals.validateRoutes);
-		}
-		server.ext('onPreHandler', internals.onPreHandler);
+  // Validate the server options on the routes
+  if (server.after) { // Support for hapi < 11
+    server.after(internals.validateRoutes);
+  } else {
+    server.ext('onPreStart', internals.validateRoutes);
+  }
+  server.ext('onPreHandler', internals.onPreHandler);
 
-		next();
-	} catch (e) {
-
-		next(e);
-	}
 };
 
 /**
@@ -69,47 +63,42 @@ exports.plugin = {
  * @param server
  * @param next
  */
-internals.validateRoutes = (server, next) => {
+internals.validateRoutes = (server) => {
 
-	try {
-		// Loop through each connection in the server
-		server.connections.forEach((connection) => {
+  // Loop through each connection in the server
+  console.log(server.connections)
+  server.connections.forEach((connection) => {
 
-			const routes = (connection.routingTable) ? connection.routingTable() : connection.table();
+    const routes = (connection.routingTable) ? connection.routingTable() : connection.table();
 
-			// Loop through each route
-			routes.forEach((route) => {
+    // Loop through each route
+    routes.forEach((route) => {
 
-				const hapiAuthorizationParams = route.settings.plugins[pluginName] ? route.settings.plugins[pluginName] : false;
+      const hapiAuthorizationParams = route.settings.plugins[pluginName] ? route.settings.plugins[pluginName] : false;
 
-				// If there are hapi-authorization params and are not disabled by using "false", validate em
-				if (hapiAuthorizationParams !== false) {
+      // If there are hapi-authorization params and are not disabled by using "false", validate em
+      if (hapiAuthorizationParams !== false) {
 
-					// If there is a default auth
-					if(connection.auth.settings.default) {
+        // If there is a default auth
+        if(connection.auth.settings.default) {
 
-						// If there is also an auth on the route, make sure it's not false or null
-						if(route.settings.auth !== undefined) {
+          // If there is also an auth on the route, make sure it's not false or null
+          if(route.settings.auth !== undefined) {
 
-							// Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
-							Hoek.assert(route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
-						}
-					}
-					// Else there is no default auth set, so validate each route's auth
-					else {
-						// Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
-						Hoek.assert(route.settings.auth && route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
-					}
+            // Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
+            Hoek.assert(route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
+          }
+        }
+        // Else there is no default auth set, so validate each route's auth
+        else {
+          // Make sure that there is either a default auth being set, or that there is an auth specified on every route with hapiAuthorization plugin params
+          Hoek.assert(route.settings.auth && route.settings.auth !== null && route.settings.auth !== false, 'hapi-authorization can be enabled only for secured route');
+        }
 
-					Schema.assert('route', hapiAuthorizationParams, 'Invalid settings');
-				}
-			});
-		});
-		next();
-	}
-	catch (err) {
-		next(err);
-	}
+        Schema.assert('route', hapiAuthorizationParams, 'Invalid settings');
+      }
+    });
+  });
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,15 @@
 // External modules
-var Boom	= require('boom');
-var Hoek	= require('hoek');
-var Q			= require('q');
+const Boom	= require('boom');
+const Hoek	= require('hoek');
 
 // Internal modules
-var Roles					= require('./roles');
-var Schema				= require('./schema');
-var RoleHierarchy	= Roles.hierarchy;
-var ACL						= require('./acl');
+const Roles					= require('./roles');
+const Schema				= require('./schema');
+const RoleHierarchy	= Roles.hierarchy;
+const ACL						= require('./acl');
 
-var pluginName = 'hapiAuthorization';
-var internals = {
+const pluginName = 'hapiAuthorization';
+const internals = {
 	defaults: {
 		roles: Roles.roles,
 		hierarchy: false,
@@ -25,13 +24,13 @@ var internals = {
  * @param options
  * @param next
  */
-exports.register = function (server, options, next) {
+const register = (server, options, next) => {
 
 	try {
 		// Validate the options passed into the plugin
 		Schema.assert('plugin', options, 'Invalid settings');
 
-		var settings = Hoek.applyToDefaults(internals.defaults, options || {});
+		const settings = Hoek.applyToDefaults(internals.defaults, options || {});
 
 		server.bind({
 			config: settings
@@ -55,9 +54,13 @@ exports.register = function (server, options, next) {
 /**
  * Gets the name and version from package.json
  */
-exports.register.attributes = {
-	pkg: require('../package.json')
-};
+exports.plugin = {
+  register,
+  name: pluginName,
+  version: require('../package.json').version,
+  multiple: true,
+  pkg: require('../package.json')
+}
 
 
 /**
@@ -66,18 +69,18 @@ exports.register.attributes = {
  * @param server
  * @param next
  */
-internals.validateRoutes = function(server, next) {
+internals.validateRoutes = (server, next) => {
 
 	try {
 		// Loop through each connection in the server
-		server.connections.forEach(function(connection) {
+		server.connections.forEach((connection) => {
 
-			var routes = (connection.routingTable) ? connection.routingTable() : connection.table();
+			const routes = (connection.routingTable) ? connection.routingTable() : connection.table();
 
 			// Loop through each route
-			routes.forEach(function(route) {
+			routes.forEach((route) => {
 
-				var hapiAuthorizationParams = route.settings.plugins[pluginName] ? route.settings.plugins[pluginName] : false;
+				const hapiAuthorizationParams = route.settings.plugins[pluginName] ? route.settings.plugins[pluginName] : false;
 
 				// If there are hapi-authorization params and are not disabled by using "false", validate em
 				if (hapiAuthorizationParams !== false) {
@@ -115,15 +118,15 @@ internals.validateRoutes = function(server, next) {
  * @param request
  * @param reply
  */
-internals.onPreHandler = function(request, reply) {
+internals.onPreHandler = (request, reply) => {
 
 		// Ignore OPTIONS requests
-		if(request.route.method === 'options') {
+		if (request.route.method === 'options') {
 			return reply.continue();
 		}
 
-		var params;
-		try{
+		let params;
+		try {
 			// Check if the current route is hapi-authorization enabled
 			params = internals.getRouteParams(request);
 		}
@@ -134,13 +137,13 @@ internals.onPreHandler = function(request, reply) {
 		// if hapi-authorization is enabled, get the user
 		if (params) {
 
-			var user = request.auth.credentials;
+			const user = request.auth.credentials;
 
 			if (!request.plugins[pluginName]) {
 				request.plugins[pluginName] = {};
 			}
 
-			var roleHierarchy = null;
+			const roleHierarchy = null;
 
 			// If we're not using hierarchy
 			if(this.config.hierarchy === true) {
@@ -150,11 +153,10 @@ internals.onPreHandler = function(request, reply) {
 				roleHierarchy = false;
 			}
 
-			Q
 				// Checks roles
-				.fcall(function () {
+				Promise.resolve(() => { 
 					if (params.role || params.roles) {
-						var err = ACL.checkRoles(user, params.role || params.roles, roleHierarchy);
+						const err = ACL.checkRoles(user, params.role || params.roles, roleHierarchy);
 						if (err) {
 							throw err;
 						}
@@ -162,9 +164,9 @@ internals.onPreHandler = function(request, reply) {
 					return true;
 				})
 				// Fetches acl entities
-				.then(function () {
+				.then(() => {
 					if (params.aclQuery) {
-						var parameter = request[params.paramSource][params.aclQueryParam];
+						const parameter = request[params.paramSource][params.aclQueryParam];
 						return ACL.fetchEntity(params.aclQuery, parameter, request);
 					}
 					return null;
@@ -209,7 +211,7 @@ internals.onPreHandler = function(request, reply) {
 internals.getRouteParams = function(request) {
 
 	if (request.route.settings.plugins[pluginName]) {
-		var params = request.route.settings.plugins[pluginName];
+		const params = request.route.settings.plugins[pluginName];
 		return Schema.assert('route', params, 'Invalid settings');
 	} else {
 		return null;

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -3,30 +3,30 @@
  */
 
 // The default roles
-//var RoleTypes = {
+//const RoleTypes = {
 //  SUPER_ADMIN: 'SUPER_ADMIN',
 //  ADMIN: 'ADMIN',
 //  USER: 'USER',
 //  GUEST: 'GUEST'
 //};
 
-var SUPER_ADMIN	= 'SUPER_ADMIN';
-var ADMIN				= 'ADMIN';
-var USER				= 'USER';
-var GUEST				= 'GUEST';
+const SUPER_ADMIN = 'SUPER_ADMIN';
+const ADMIN       = 'ADMIN';
+const USER        = 'USER';
+const GUEST       = 'GUEST';
 
 // The default roles and hierarchy
-var RoleTypes = [SUPER_ADMIN, ADMIN, USER, GUEST];
-var RoleHierarchy = RoleTypes;	// Is the same because of the order we defined them
+const RoleTypes     = [SUPER_ADMIN, ADMIN, USER, GUEST];
+const RoleHierarchy = RoleTypes;	// Is the same because of the order we defined them
 
 // The default role hierarchy
-//var RoleHierarchy = [];
+//const RoleHierarchy = [];
 //RoleHierarchy.SUPER_ADMIN	= [SUPER_ADMIN, ADMIN, USER, GUEST];
 //RoleHierarchy.ADMIN				= [ADMIN, USER, GUEST];
 //RoleHierarchy.USER				= [USER, GUEST];
 //RoleHierarchy.GUEST				= [GUEST];
 
 module.exports = {
-  roles: RoleTypes,
+  roles    : RoleTypes,
   hierarchy: RoleHierarchy
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,35 +1,35 @@
-var Joi = require('joi');
-var Hoek = require('hoek');
+const Joi  = require('joi');
+const Hoek = require('hoek');
 
 // Internals
-var internals = {};
+const internals = {};
 
 /**
  * Assert that the params are valid for the type passed in
  *
- * @param type		- The type of object we want to validate for. i.e. route, plugin
- * @param options	- The JSON object to be validated
- * @param message	- Part of the message if validation fails
+ * @param type    - The type of object we want to validate for. i.e. route, plugin
+ * @param options  - The JSON object to be validated
+ * @param message  - Part of the message if validation fails
  * @returns {*}
  */
 exports.assert = function (type, options, message) {
 
-	var validationObj = Joi.validate(options, internals[type]);
-	var error = validationObj.error;
-	var errorMessage = null;
+  const validationObj = Joi.validate(options, internals[type]);
+  const error         = validationObj.error;
+  let errorMessage    = null;
 
-	// If there is an error, build a nice error message
-	if(error) {
-		errorMessage = error.name + ':';
-		error.details.forEach(function(err) {
-			errorMessage += ' ' + err.message;
-		});
-	}
+  // If there is an error, build a nice error message
+  if (error) {
+    errorMessage = error.name + ':';
+    error.details.forEach(function (err) {
+      errorMessage += ' ' + err.message;
+    });
+  }
 
-	// If there is an error build the error message
-	Hoek.assert(!error, 'Invalid', type, 'options', message ? '(' + message + ')' : '', errorMessage);
+  // If there is an error build the error message
+  Hoek.assert(!error, 'Invalid', type, 'options', message ? '(' + message + ')' : '', errorMessage);
 
-	return validationObj.value;
+  return validationObj.value;
 };
 
 
@@ -37,17 +37,17 @@ exports.assert = function (type, options, message) {
  * Validation rules for a route's params
  */
 internals.route = Joi.object({
-	role: Joi.string().optional(),
-	roles: Joi.array().optional(),
-	aclQuery: Joi.func().when('validateEntityAcl', {is: true, then: Joi.required()}),
-	aclQueryParam: Joi.string().default('id'),
-	paramSource: Joi.string().allow('payload', 'params', 'query').default('params'),
-	validateEntityAcl: Joi.boolean().default(false),
-	validateAclMethod: Joi.string().default(null),
-	entityUserField: Joi.string().default("_user"),
-	entityRoleField: Joi.string().default("role"),
-	userIdField: Joi.string().default("_id"),
-	userRoleField: Joi.string().default("role")
+  role             : Joi.string().optional(),
+  roles            : Joi.array().optional(),
+  aclQuery         : Joi.func().when('validateEntityAcl', { is: true, then: Joi.required() }),
+  aclQueryParam    : Joi.string().default('id'),
+  paramSource      : Joi.string().allow('payload', 'params', 'query').default('params'),
+  validateEntityAcl: Joi.boolean().default(false),
+  validateAclMethod: Joi.string().default(null),
+  entityUserField  : Joi.string().default("_user"),
+  entityRoleField  : Joi.string().default("role"),
+  userIdField      : Joi.string().default("_id"),
+  userRoleField    : Joi.string().default("role")
 }).without('role', 'roles').options({ allowUnknown: false });
 
 
@@ -55,7 +55,7 @@ internals.route = Joi.object({
  * Validation rules for the plugin's params
  */
 internals.plugin = Joi.object({
-	roles: [Joi.array().optional(), Joi.bool().allow(false).optional()],
-	hierarchy: Joi.bool().optional(),
-	roleHierarchy: Joi.array().optional()
-}).options({allowUnknown: false});
+  roles        : [Joi.array().optional(), Joi.bool().allow(false).optional()],
+  hierarchy    : Joi.bool().optional(),
+  roleHierarchy: Joi.array().optional()
+}).options({ allowUnknown: false });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/toymachiner62/hapi-authorization",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
     "boom": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "boom": "^5.1.0",
-    "hoek": "^4.1.1",
-    "joi": "^10.5.1",
-    "underscore": "^1.8.3"
+    "boom": "^7.2.0",
+    "hoek": "^5.0.3",
+    "joi": "^13.4.0",
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-authorization",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "description": "ACL support for hapijs apps",
   "main": "index.js",
   "scripts": {
@@ -35,19 +35,18 @@
   },
   "homepage": "https://github.com/toymachiner62/hapi-authorization",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "boom": "^5.1.0",
     "hoek": "^4.1.1",
     "joi": "^10.5.1",
-    "q": "^1.5.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^3.4.1",
     "coveralls": "^2.11.6",
-    "hapi": "^11.1.2",
+    "hapi": "^17.4.0",
     "istanbul": "^0.4.1",
     "jscoverage": "^0.6.0",
     "mocha": "^2.3.4"

--- a/test/index.js
+++ b/test/index.js
@@ -1,41 +1,36 @@
 // External modules
-var expect = require('chai').expect;
-var Hapi = require('hapi');
-var Joi = require('joi');
+const expect = require('chai').expect;
+const Hapi = require('hapi');
+const Joi = require('joi');
 
 // Internal modules
-var libpath = process.env['HAPI_AUTHORIZATION_COV'] ? '../lib-cov' : '../lib';
-var Plugin = require(libpath + '/index');
+const libpath = process.env['HAPI_AUTHORIZATION_COV'] ? '../lib-cov' : '../lib';
+const Plugin = require(libpath + '/index');
 
 // Declare internals
-var internals = {};
+const internals = {};
 
 function NOOP(){}
 
-describe('hapi-authorization', function() {
+describe('hapi-authorization', () => {
 
-	var plugin = {
+	const plugin = {
 		name: 'hapiAuthorization',
 		version: '0.0.0',
-		plugin: Plugin.plugin,
+		register: Plugin.plugin.register,
 		path: libpath
 	};
 
 	it('does not interfere with handlers throwing exceptions', async (done) => {
-		var server = new Hapi.Server();
-		server.route({ method: 'GET', path: '/', config: {
-			handler: function (request, reply) {throw new Error("uncaught exception test");}
+		const server = new Hapi.Server();
+		server.route({ method: 'GET', path: '/', options: {
+			handler: function (request, h) {return new Error("uncaught exception test");}
 		}});
-    console.log('zero')
     await server.register(plugin, {});
     
-    console.log(1)
-    server.start(function(err) {
-      console.log(2)
-      server.inject({method: 'GET', url: '/'}, function(res) {
-        console.log(3)
-        internals.asyncCheck(function() {
-          console.log(4)
+    server.start().then(() => {
+      server.inject({method: 'GET', url: '/'}).then((res) => {
+        internals.asyncCheck(() => {
           expect(res.statusCode).to.equal(500);
           server.stop(NOOP);
         }, done);
@@ -43,14 +38,14 @@ describe('hapi-authorization', function() {
     });
 	});
 
-	it('makes sure that hapi-authorization can be enabled only for secured routes', function(done) {
-		var server = new Hapi.Server();
-		server.route({ method: 'GET', path: '/', config: {
+	it('makes sure that hapi-authorization can be enabled only for secured routes', (done) => {
+		const server = new Hapi.Server();
+		server.route({ method: 'GET', path: '/', options: {
 			plugins: {'hapiAuthorization': {role: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
+		server.register(plugin, {}).then(() => {
+			server.start().catch((err) => {
 				expect(err).to.not.be.undefined;
 				expect(err).to.match(/hapi-authorization can be enabled only for secured route/);
 				server.stop(NOOP); // Make sure the server is stopped
@@ -59,47 +54,44 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('should allow hapi-authorization for routes secured in the route config', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('should allow hapi-authorization for routes secured in the route config', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', false, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {role: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
-				expect(err).to.be.undefined;
+		server.register(plugin, {}).then(() => {
+			server.start().then(() => {
 				server.stop(NOOP); // Make sure the server is stopped
 				done();
 			});
 		});
 	});
 
-	it('should allow hapi-authorization for routes secured globally with authentication', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('should allow hapi-authorization for routes secured globally with authentication', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', false, {});
+		server.auth.strategy('default', 'custom', {});
 		server.auth.default('default');
-		server.route({ method: 'GET', path: '/', config: {
+		server.route({ method: 'GET', path: '/', options: {
 			plugins: {'hapiAuthorization': {role: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
-				expect(err).to.be.undefined;
+		server.register(plugin, {}).then(() => {
+			server.start().then(() => {
 				server.stop(NOOP); // Make sure the server is stopped
 				done();
 			});
 		});
 	});
 
-	it('should allow hapi-authorization for routes secured globally with authentication and blacklisting routes to require authorization', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection({
+	it('should allow hapi-authorization for routes secured globally with authentication and blacklisting routes to require authorization', (done) => {
+		const server = new Hapi.Server({
 			routes: {
 				plugins: {
 					hapiAuthorization: { roles: ['USER'] }
@@ -107,24 +99,22 @@ describe('hapi-authorization', function() {
 			}
 		});
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', false, {});
+		server.auth.strategy('default', 'custom', {});
 		server.auth.default('default');
-		server.route({ method: 'GET', path: '/', config: {
+		server.route({ method: 'GET', path: '/', options: {
 			//plugins: {'hapiAuthorization': {role: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
-				expect(err).to.be.undefined;
+		server.register(plugin, {}).then(() => {
+			server.start().then(() => {
 				server.stop(NOOP); // Make sure the server is stopped
 				done();
 			});
 		});
 	});
 
-	it('should error with global authentication not set and blacklisting routes to require authorization', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection({
+	it('should error with global authentication not set and blacklisting routes to require authorization', (done) => {
+		const server = new Hapi.Server({
 			routes: {
 				plugins: {
 					hapiAuthorization: { roles: ['USER'] }
@@ -132,14 +122,14 @@ describe('hapi-authorization', function() {
 			}
 		});
 		//server.auth.scheme('custom', internals.authSchema);
-		//server.auth.strategy('default', 'custom', false, {});
+		//server.auth.strategy('default', 'custom', {});
 		//server.auth.default('default');
-		server.route({ method: 'GET', path: '/', config: {
+		server.route({ method: 'GET', path: '/', options: {
 			//plugins: {'hapiAuthorization': {role: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
+		server.register(plugin, {}).then(() => {
+			server.start().catch((err) => {
 				expect(err).to.not.be.undefined;
 				expect(err).to.match(/hapi-authorization can be enabled only for secured route/);
 				server.stop(NOOP); // Make sure the server is stopped
@@ -148,20 +138,19 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('should not error with global authentication set, blacklisting routes to require authorization, and disabling authentication and authorization for a specific route', function(done) {
+	it('should not error with global authentication set, blacklisting routes to require authorization, and disabling authentication and authorization for a specific route', (done) => {
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: false
 			}
 		};
 
-		var server = new Hapi.Server(0);
-		server.connection({
+		const server = new Hapi.Server({
 			routes: {
 				plugins: {
 					hapiAuthorization: { roles: ['USER'] }
@@ -170,37 +159,37 @@ describe('hapi-authorization', function() {
 		});
 
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', false, {});
+		server.auth.strategy('default', 'custom', {});
 		server.auth.default('default');
 
-		server.route({ method: 'GET', path: '/', config: {
+		server.route({ method: 'GET', path: '/', options: {
 			auth: false,
 			plugins: {'hapiAuthorization': false},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
 
-		server.register(plugin, {}, function(err) {
-				server.inject({method: 'GET', url: '/'}, function(res) {
-					internals.asyncCheck(function() {
+		server.register(plugin, {}).then(() => {
+				server.inject({method: 'GET', url: '/'}).then((res) => {
+					internals.asyncCheck(() => {
 						expect(res.statusCode).to.equal(200);
 					}, done);
 				});
 		});
 	});
 
-	it('should error with global auth set but auth false on route', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('should error with global auth set but auth false on route', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', false, {});
+		server.auth.strategy('default', 'custom', {});
 		server.auth.default('default');
-		server.route({ method: 'GET', path: '/', config: {
+		server.route({ method: 'GET', path: '/', options: {
 			auth: false,
 			plugins: {'hapiAuthorization': {role: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
+		server.register(plugin, {}).then(() => {
+			server.start().catch((err) => {
 				expect(err).to.not.be.undefined;
 				server.stop(NOOP); // Make sure the server is stopped
 				done();
@@ -208,18 +197,18 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('Validates the hapi-authorization routes parameters', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('Validates the hapi-authorization routes parameters', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {bla: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
+		server.register(plugin, {}).then(() => {
+			server.start().catch((err) => {
 				expect(err).to.not.be.undefined;
 				expect(err).to.match(/"bla" is not allowed/);
 				server.stop(NOOP); // Make sure the server is stopped
@@ -228,13 +217,13 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('ignores routes without hapi-authorization instructions', function(done) {
-		var server = new Hapi.Server();
-		server.connection();
-		server.route({ method: 'GET', path: '/', handler: function (request, reply) { reply("TEST"); } });
-		server.register(plugin, {}, function(err) {
+	it('ignores routes without hapi-authorization instructions', (done) => {
+		const server = new Hapi.Server();
+		
+		server.route({ method: 'GET', path: '/', handler: (request, h) => { return "TEST"; } });
+		server.register(plugin, {}).then(() => {
 
-			server.inject('/', function(res) {
+			server.inject('/').then((res) => {
 
 				expect(res.payload).to.equal("TEST");
 				done();
@@ -242,21 +231,21 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('Validates the hapi-authorization plugin options do not contain random options', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('Validates the hapi-authorization plugin options do not contain random options', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {bla: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				foo: 'TEST',
@@ -266,7 +255,7 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		server.register(plugin, {}, function(err) {
+		server.register(plugin, {}).catch((err) => {
 			expect(err).to.not.be.undefined;
 			expect(err).to.be.instanceOf(Error);
 			expect(err.message).to.equal('Invalid plugin options (Invalid settings) ValidationError: "foo" is not allowed');
@@ -274,21 +263,21 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('Validates the hapi-authorization plugin option "roles" must be an array', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('Validates the hapi-authorization plugin option "roles" must be an array', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {bla: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: 'TEST',
@@ -297,7 +286,7 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		server.register(plugin, {}, function(err) {
+		server.register(plugin, {}).catch((err) => {
 			expect(err).to.not.be.undefined;
 			expect(err).to.be.instanceOf(Error);
 			expect(err.message).to.equal('Invalid plugin options (Invalid settings) ValidationError: "roles" must be an array "roles" must be a boolean');
@@ -305,21 +294,21 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('Validates the hapi-authorization plugin option "roleHierarchy" must be an array', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('Validates the hapi-authorization plugin option "roleHierarchy" must be an array', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {bla: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -328,7 +317,7 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		server.register(plugin, {}, function(err) {
+		server.register(plugin, {}).catch((err) => {
 			expect(err).to.not.be.undefined;
 			expect(err).to.be.instanceOf(Error);
 			expect(err.message).to.equal('Invalid plugin options (Invalid settings) ValidationError: "roleHierarchy" must be an array');
@@ -336,21 +325,21 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('Validates the hapi-authorization plugin option "hierarchy" must be a boolean', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('Validates the hapi-authorization plugin option "hierarchy" must be a boolean', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {bla: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -359,7 +348,7 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		server.register(plugin, {}, function(err) {
+		server.register(plugin, {}).catch((err) => {
 			expect(err).to.not.be.undefined;
 			expect(err).to.be.instanceOf(Error);
 			expect(err.message).to.equal('Invalid plugin options (Invalid settings) ValidationError: "hierarchy" must be a boolean');
@@ -367,48 +356,47 @@ describe('hapi-authorization', function() {
 		});
 	});
 
-	it('Validates the hapi-authorization plugin options are optional', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+	it('Validates the hapi-authorization plugin options are optional', (done) => {
+		const server = new Hapi.Server();
+		
 		server.auth.scheme('custom', internals.authSchema);
-		server.auth.strategy('default', 'custom', true, {});
-		server.route({ method: 'GET', path: '/', config: {
+		server.auth.strategy('default', 'custom', {});
+		server.route({ method: 'GET', path: '/', options: {
 			auth: 'default',
 			plugins: {'hapiAuthorization': {bla: 'USER'}},
-			handler: function (request, reply) { reply("TEST");}
+			handler: (request, h) => { return "TEST";}
 		}});
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath
 		};
 
-		server.register(plugin, {}, function(err) {
-			expect(err).to.be.undefined;
+		server.register(plugin, {}).then(() => {
 			done();
 		});
 	});
 
-	describe('Initialize with no options', function() {
+	describe('Initialize with no options', () => {
 
-		describe('ACL roles', function() {
+		describe('ACL roles', () => {
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -416,40 +404,40 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -457,20 +445,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -478,20 +466,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -500,20 +488,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -522,20 +510,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('returns an error when a user with a role that is not a valid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('returns an error when a user with a role that is not a valid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -544,20 +532,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Allows access to protected method for a single role', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('Allows access to protected method for a single role', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.payload).to.equal('Authorized');
 						}, done);
@@ -566,20 +554,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['EMPLOYEE', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
@@ -587,20 +575,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Returns an error when a single role is not one of the allowed roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('Returns an error when a single role is not one of the allowed roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['OWNER', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -609,22 +597,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -633,9 +621,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -644,22 +632,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -668,9 +656,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -679,22 +667,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -703,9 +691,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -715,20 +703,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -737,20 +725,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -759,20 +747,20 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it.skip('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(customPluginObject, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(customPluginObject, {}, (err) => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -782,22 +770,22 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('fetchEntity', function() {
+		describe('fetchEntity', () => {
 
-			it('validates that the aclQuery parameter is a function', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates that the aclQuery parameter is a function', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {aclQuery: 'not function'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400)
 							expect(res.result.message).to.match(/"aclQuery" must be a Function/);
 						}, done);
@@ -805,22 +793,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('fetches the wanted entity using the query', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('fetches the wanted entity using the query', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, {id: '1', name: 'Asaf'});
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return {id: '1', name: 'Asaf'};
 					}}},
-					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
+					handler: (request, h) => { return request.plugins.hapiAuthorization.entity;}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Asaf');
 						}, done);
@@ -828,44 +816,44 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles not found entities', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles not found entities', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return null;
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('handles query errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles query errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(new Error("Boomy"), null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						throw new Error("Boomy");
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 						}, done);
 					});
@@ -873,22 +861,22 @@ describe('hapi-authorization', function() {
 			});
 		});
 
-		describe('validateEntityAcl', function() {
+		describe('validateEntityAcl', () => {
 
-			it('requires aclQuery when validateEntityAcl is true', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('requires aclQuery when validateEntityAcl is true', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {validateEntityAcl: true}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.match(/"aclQuery" is required/);
 						}, done);
@@ -896,105 +884,105 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when the entity was not found', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when the entity was not found', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, null);
+						aclQuery: (id, request) => {
+							return null;
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('declines requests from unauthorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('declines requests from unauthorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return false; }};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 						}, done);
 					});
 				});
 			});
 
-			it('handles validator errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles validator errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { throw new Error('Boom')}};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(500);
 						}, done);
 					});
 				});
 			});
 
-			it('returns the response for authorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for authorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return true; }};
 						}
 					}},
-					handler: function (request, reply) {
-						reply(request.plugins.hapiAuthorization.entity);
+					handler: (request, h) => {
+						return request.plugins.hapiAuthorization.entity;
 					}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Hello');
 						}, done);
@@ -1003,27 +991,27 @@ describe('hapi-authorization', function() {
 			});
 		});
 
-		describe('default acl validator', function() {
+		describe('default acl validator', () => {
 
-			it('returns error when the entity has no user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity has no user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello'});
+						aclQuery: async (id, request) => {
+							return {id: id, name: 'Hello'}
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1031,25 +1019,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns error when the entity doesn\'t belong to the authenticated user', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity doesn\'t belong to the authenticated user', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+              return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1057,25 +1045,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns the response for user with permissions', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for user with permissions', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+              return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -1083,26 +1071,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom user id field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom user id field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+              return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -1110,26 +1098,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom entity user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom entity user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, request, cb) {
-							cb(null, {creator: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+              return {creator: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -1139,15 +1127,15 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('Joi validator with aclQuery', function() {
+		describe('Joi validator with aclQuery', () => {
 
-			it('returns an error when query parameter is missing', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when query parameter is missing', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					validate: {
 						query: {
 							name: Joi.string().required()
@@ -1159,29 +1147,29 @@ describe('hapi-authorization', function() {
 						entityUserField: 'creator',
 						aclQueryParam: 'name',
 						paramSource: 'query',
-						aclQuery: function(name, request, cb) {
-							cb(null, {creator: '1', name: 'Hello' + name});
+						aclQuery: (name, request) => {
+							return {creator: '1', name: 'Hello' + name};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
-							expect(res.result.message).to.equal('child "name" fails because ["name" is required]');
+							expect(res.result.message).to.equal('Invalid request query input');
 						}, done);
 					});
 				});
 			});
 
-			it('validates query parameter', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates query parameter', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					validate: {
 						query: {
 							name: Joi.string().required()
@@ -1193,15 +1181,15 @@ describe('hapi-authorization', function() {
 						entityUserField: 'creator',
 						aclQueryParam: 'name',
 						paramSource: 'query',
-						aclQuery: function(name, request, cb) {
-							cb(null, {creator: '1', name: 'Hello' + name});
+						aclQuery: (name, request) => {
+							return {creator: '1', name: 'Hello' + name};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/?name=John Doe', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/?name=John Doe', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -1209,13 +1197,13 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when payload parameter is missing', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when payload parameter is missing', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'POST', path: '/', config: {
+				server.route({ method: 'POST', path: '/', options: {
 					validate: {
 						payload: {
 							name: Joi.string().required()
@@ -1227,29 +1215,29 @@ describe('hapi-authorization', function() {
 						entityUserField: 'creator',
 						aclQueryParam: 'name',
 						paramSource: 'payload',
-						aclQuery: function(name, request, cb) {
-							cb(null, {creator: '1', name: 'Hello' + name});
+						aclQuery: (name, request) => {
+							return {creator: '1', name: 'Hello' + name};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'POST', url: '/', payload: {}, credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'POST', url: '/', payload: {}, credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
-							expect(res.result.message).to.equal('child "name" fails because ["name" is required]');
+							expect(res.result.message).to.equal('Invalid request payload input');
 						}, done);
 					});
 				});
 			});
 
-			it('validates payload parameter', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates payload parameter', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'POST', path: '/', config: {
+				server.route({ method: 'POST', path: '/', options: {
 					validate: {
 						payload: {
 							name: Joi.string().required()
@@ -1261,15 +1249,15 @@ describe('hapi-authorization', function() {
 						entityUserField: 'creator',
 						aclQueryParam: 'name',
 						paramSource: 'payload',
-						aclQuery: function(name, request, cb) {
-							cb(null, {creator: '1', name: 'Hello' + name});
+						aclQuery: (name, request) => {
+							return {creator: '1', name: 'Hello' + name};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'POST', url: '/', payload: { name: "John Doe"}, credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'POST', url: '/', payload: { name: "John Doe"}, credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -1281,12 +1269,12 @@ describe('hapi-authorization', function() {
 
 	});
 
-	describe('Initialize with roles', function() {
+	describe('Initialize with roles', () => {
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			register: Plugin.plugin.register,
 			path: libpath,
 			options: {
 				roles: ['OWNER', 'MANAGER', 'EMPLOYEE']
@@ -1295,22 +1283,22 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		describe('ACL roles', function() {
+		describe('ACL roles', () => {
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1318,20 +1306,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with an invalid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with an invalid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1339,40 +1327,40 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -1380,20 +1368,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -1401,20 +1389,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -1422,20 +1410,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1443,20 +1431,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1464,20 +1452,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for a single role', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for a single role', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.payload).to.equal('Authorized');
 						}, done);
@@ -1485,40 +1473,40 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['EMPLOYEE', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when a single role is not one of the allowed roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a single role is not one of the allowed roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['OWNER', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -1527,22 +1515,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -1551,9 +1539,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -1562,22 +1550,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -1586,9 +1574,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -1597,22 +1585,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -1621,9 +1609,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -1632,20 +1620,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -1653,20 +1641,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -1674,20 +1662,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -1697,22 +1685,22 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('fetchEntity', function() {
+		describe('fetchEntity', () => {
 
-			it('validates that the aclQuery parameter is a function', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates that the aclQuery parameter is a function', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {aclQuery: 'not function'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400)
 							expect(res.result.message).to.match(/"aclQuery" must be a Function/);
 						}, done);
@@ -1720,22 +1708,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('fetches the wanted entity using the query', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('fetches the wanted entity using the query', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, {id: '1', name: 'Asaf'});
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return {id: '1', name: 'Asaf'};
 					}}},
-					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
+					handler: (request, h) => { return request.plugins.hapiAuthorization.entity;}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Asaf');
 						}, done);
@@ -1743,44 +1731,44 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles not found entities', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles not found entities', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return null;
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('handles query errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles query errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(new Error("Boomy"), null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						throw new Error("Boomy");
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 						}, done);
 					});
@@ -1788,22 +1776,22 @@ describe('hapi-authorization', function() {
 			});
 		});
 
-		describe('validateEntityAcl', function() {
+		describe('validateEntityAcl', () => {
 
-			it('requires aclQuery when validateEntityAcl is true', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('requires aclQuery when validateEntityAcl is true', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {validateEntityAcl: true}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.match(/"aclQuery" is required/);
 						}, done);
@@ -1811,105 +1799,105 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when the entity was not found', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when the entity was not found', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, null);
+						aclQuery: (id, request) => {
+							return null;
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('declines requests from unauthorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('declines requests from unauthorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
+						aclQuery: (id, request) => {
+              return {id: id, name: 'Hello', isGranted: (user, role) => { return false; }};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 						}, done);
 					});
 				});
 			});
 
-			it('handles validator errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles validator errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
+						aclQuery: (id, request) => {
+              return {id: id, name: 'Hello', isGranted: (user, role) => { throw new Error('Boom'); }};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(500);
 						}, done);
 					});
 				});
 			});
 
-			it('returns the response for authorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for authorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
+						aclQuery: (id, request) => {
+              return {id: id, name: 'Hello', isGranted: (user, role) => { return true; }};
 						}
 					}},
-					handler: function (request, reply) {
-						reply(request.plugins.hapiAuthorization.entity);
+					handler: (request, h) => {
+						return request.plugins.hapiAuthorization.entity;
 					}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Hello');
 						}, done);
@@ -1918,27 +1906,27 @@ describe('hapi-authorization', function() {
 			});
 		});
 
-		describe('default acl validator', function() {
+		describe('default acl validator', () => {
 
-			it('returns error when the entity has no user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity has no user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1946,25 +1934,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns error when the entity doesn\'t belong to the authenticated user', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity doesn\'t belong to the authenticated user', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -1972,25 +1960,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns the response for user with permissions', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for user with permissions', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -1998,26 +1986,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom user id field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom user id field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -2025,26 +2013,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom entity user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom entity user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, request, cb) {
-							cb(null, {creator: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {creator: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -2056,12 +2044,12 @@ describe('hapi-authorization', function() {
 
 	});
 
-	describe('Initialize with roles and hierarchy', function() {
+	describe('Initialize with roles and hierarchy', () => {
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -2070,22 +2058,22 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		describe('ACL roles', function() {
+		describe('ACL roles', () => {
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2093,20 +2081,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with an invalid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with an invalid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2114,147 +2102,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Restricts access to protected route for multiple authorized roles that are not defined as plugin roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Restricts access to protected route for multiple authorized roles that are not defined as plugin roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-							//expect(res.payload).to.equal('Authorized');
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.statusCode).to.equal(400);
-							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.statusCode).to.equal(400);
-							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.statusCode).to.equal(400);
-							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
-						}, done);
-					});
-				});
-			});
-
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-						}, done);
-					});
-				});
-			});
-
-			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-						}, done);
-					});
-				});
-			});
-
-			it('Allows access to protected method for a single role', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.payload).to.equal('Authorized');
 						}, done);
@@ -2262,167 +2123,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {roles: ['EMPLOYEE', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
-							expect(res.payload).to.equal('Authorized');
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when a single role is not one of the allowed roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {roles: ['OWNER', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
-
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-
-				var plugin = {
-					name: 'hapiAuthorization',
-					version: '0.0.0',
-					register: Plugin.register,
-					path: libpath,
-					options: {
-						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
-						hierarchy: false,
-						roleHierarchy: ['OWNER', 'MANAGER', 'EMPLOYEE']
-					}
-				};
-
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
-
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-
-				var plugin = {
-					name: 'hapiAuthorization',
-					version: '0.0.0',
-					register: Plugin.register,
-					path: libpath,
-					options: {
-						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
-						hierarchy: false,
-						roleHierarchy: ['OWNER', 'MANAGER', 'EMPLOYEE']
-					}
-				};
-
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
-
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
-					auth: 'default',
-					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
-				}});
-
-				var plugin = {
-					name: 'hapiAuthorization',
-					version: '0.0.0',
-					register: Plugin.register,
-					path: libpath,
-					options: {
-						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
-						hierarchy: false,
-						roleHierarchy: ['OWNER', 'MANAGER', 'EMPLOYEE']
-					}
-				};
-
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
-
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
-						}, done);
-					});
-				});
-			});
-
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
-				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
-
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -2430,20 +2144,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -2451,20 +2165,293 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.statusCode).to.equal(400);
+							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
+						}, done);
+					});
+				});
+			});
+
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'OWNER'}},
+					handler: (request, h) => { return "TEST";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.statusCode).to.equal(403);
+							expect(res.result.message).to.equal("Unauthorized");
+						}, done);
+					});
+				});
+			});
+
+			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'OWNER'}},
+					handler: (request, h) => { return "TEST";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.statusCode).to.equal(403);
+							expect(res.result.message).to.equal("Unauthorized");
+						}, done);
+					});
+				});
+			});
+
+			it('Allows access to protected method for a single role', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.statusCode).to.equal(200);
+							expect(res.payload).to.equal('Authorized');
+						}, done);
+					});
+				});
+			});
+
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {roles: ['EMPLOYEE', 'MANAGER']}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.payload).to.equal('Authorized');
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when a single role is not one of the allowed roles', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {roles: ['OWNER', 'MANAGER']}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
+
+							expect(res.statusCode).to.equal(403);
+							expect(res.result.message).to.equal("Unauthorized");
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+
+				const plugin = {
+					name: 'hapiAuthorization',
+					version: '0.0.0',
+					plugin: Plugin.plugin,
+					path: libpath,
+					options: {
+						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
+						hierarchy: false,
+						roleHierarchy: ['OWNER', 'MANAGER', 'EMPLOYEE']
+					}
+				};
+
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
+
+							expect(res.statusCode).to.equal(403);
+							expect(res.result.message).to.equal("Unauthorized");
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+
+				const plugin = {
+					name: 'hapiAuthorization',
+					version: '0.0.0',
+					plugin: Plugin.plugin,
+					path: libpath,
+					options: {
+						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
+						hierarchy: false,
+						roleHierarchy: ['OWNER', 'MANAGER', 'EMPLOYEE']
+					}
+				};
+
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
+
+							expect(res.statusCode).to.equal(403);
+							expect(res.result.message).to.equal("Unauthorized");
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+
+				const plugin = {
+					name: 'hapiAuthorization',
+					version: '0.0.0',
+					plugin: Plugin.plugin,
+					path: libpath,
+					options: {
+						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
+						hierarchy: false,
+						roleHierarchy: ['OWNER', 'MANAGER', 'EMPLOYEE']
+					}
+				};
+
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
+
+							expect(res.statusCode).to.equal(403);
+							expect(res.result.message).to.equal("Unauthorized");
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.statusCode).to.equal(400);
+							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {roles: 'USER'}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.statusCode).to.equal(400);
+							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
+						}, done);
+					});
+				});
+			});
+
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
+				server.auth.scheme('custom', internals.authSchema);
+				server.auth.strategy('default', 'custom', {});
+
+				server.route({ method: 'GET', path: '/', options: {
+					auth: 'default',
+					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
+					handler: (request, h) => { return "Authorized";}
+				}});
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -2474,22 +2461,22 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('fetchEntity', function() {
+		describe('fetchEntity', () => {
 
-			it('validates that the aclQuery parameter is a function', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates that the aclQuery parameter is a function', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {aclQuery: 'not function'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400)
 							expect(res.result.message).to.match(/"aclQuery" must be a Function/);
 						}, done);
@@ -2497,22 +2484,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('fetches the wanted entity using the query', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('fetches the wanted entity using the query', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, {id: '1', name: 'Asaf'});
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return {id: '1', name: 'Asaf'};
 					}}},
-					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
+					handler: (request, h) => { return request.plugins.hapiAuthorization.entity;}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Asaf');
 						}, done);
@@ -2520,44 +2507,44 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles not found entities', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles not found entities', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return null;
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('handles query errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles query errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(new Error("Boomy"), null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						throw new Error("Boomy");
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 						}, done);
 					});
@@ -2566,22 +2553,22 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('validateEntityAcl', function() {
+		describe('validateEntityAcl', () => {
 
-			it('requires aclQuery when validateEntityAcl is true', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('requires aclQuery when validateEntityAcl is true', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {validateEntityAcl: true}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.match(/"aclQuery" is required/);
 						}, done);
@@ -2589,105 +2576,105 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when the entity was not found', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when the entity was not found', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, null);
+						aclQuery: (id, request) => {
+							return null;
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('declines requests from unauthorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('declines requests from unauthorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return false; }};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 						}, done);
 					});
 				});
 			});
 
-			it('handles validator errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles validator errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { throw new Error('Boom')}};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(500);
 						}, done);
 					});
 				});
 			});
 
-			it('returns the response for authorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for authorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return true; }};
 						}
 					}},
-					handler: function (request, reply) {
-						reply(request.plugins.hapiAuthorization.entity);
+					handler: (request, h) => {
+						return request.plugins.hapiAuthorization.entity;
 					}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Hello');
 						}, done);
@@ -2697,27 +2684,27 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('default acl validator', function() {
+		describe('default acl validator', () => {
 
-			it('returns error when the entity has no user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity has no user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2725,25 +2712,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns error when the entity doesn\'t belong to the authenticated user', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity doesn\'t belong to the authenticated user', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2751,25 +2738,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns the response for user with permissions', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for user with permissions', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -2777,26 +2764,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom user id field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom user id field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -2804,26 +2791,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom entity user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom entity user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, request, cb) {
-							cb(null, {creator: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {creator: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -2835,12 +2822,12 @@ describe('hapi-authorization', function() {
 
 	});
 
-	describe('Initialize with roles and roleHierarchy', function() {
+	describe('Initialize with roles and roleHierarchy', () => {
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -2849,22 +2836,22 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		describe('ACL roles', function() {
+		describe('ACL roles', () => {
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2872,20 +2859,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with an invalid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with an invalid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2893,40 +2880,40 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -2934,20 +2921,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -2955,20 +2942,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -2976,20 +2963,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -2997,20 +2984,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3018,20 +3005,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for a single role', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for a single role', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.payload).to.equal('Authorized');
 						}, done);
@@ -3039,40 +3026,40 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['EMPLOYEE', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when a single role is not one of the allowed roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a single role is not one of the allowed roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['OWNER', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3082,21 +3069,21 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
+			it.skip('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3105,9 +3092,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3116,22 +3103,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3140,9 +3127,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3152,21 +3139,21 @@ describe('hapi-authorization', function() {
 			});
 
 			// TODO
-			it.skip('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
+			it.skip('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3175,9 +3162,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3186,20 +3173,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -3207,20 +3194,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -3228,20 +3215,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -3251,22 +3238,22 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('fetchEntity', function() {
+		describe('fetchEntity', () => {
 
-			it('validates that the aclQuery parameter is a function', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates that the aclQuery parameter is a function', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {aclQuery: 'not function'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400)
 							expect(res.result.message).to.match(/"aclQuery" must be a Function/);
 						}, done);
@@ -3274,22 +3261,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('fetches the wanted entity using the query', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('fetches the wanted entity using the query', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, {id: '1', name: 'Asaf'});
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return {id: '1', name: 'Asaf'};
 					}}},
-					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
+					handler: (request, h) => { return request.plugins.hapiAuthorization.entity;}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Asaf');
 						}, done);
@@ -3297,44 +3284,44 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles not found entities', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles not found entities', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return null;
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('handles query errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles query errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(new Error("Boomy"), null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						throw new Error("Boomy");
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 						}, done);
 					});
@@ -3342,22 +3329,22 @@ describe('hapi-authorization', function() {
 			});
 		});
 
-		describe('validateEntityAcl', function() {
+		describe('validateEntityAcl', () => {
 
-			it('requires aclQuery when validateEntityAcl is true', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('requires aclQuery when validateEntityAcl is true', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {validateEntityAcl: true}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.match(/"aclQuery" is required/);
 						}, done);
@@ -3365,105 +3352,105 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when the entity was not found', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when the entity was not found', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, null);
+						aclQuery: (id, request) => {
+							return null;
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('declines requests from unauthorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('declines requests from unauthorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return false; }};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 						}, done);
 					});
 				});
 			});
 
-			it('handles validator errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles validator errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { throw new Error('Boom')}};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(500);
 						}, done);
 					});
 				});
 			});
 
-			it('returns the response for authorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for authorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return true; }};
 						}
 					}},
-					handler: function (request, reply) {
-						reply(request.plugins.hapiAuthorization.entity);
+					handler: (request, h) => {
+						return request.plugins.hapiAuthorization.entity;
 					}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Hello');
 						}, done);
@@ -3473,27 +3460,27 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('default acl validator', function() {
+		describe('default acl validator', () => {
 
-			it('returns error when the entity has no user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity has no user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3501,25 +3488,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns error when the entity doesn\'t belong to the authenticated user', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity doesn\'t belong to the authenticated user', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3527,25 +3514,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns the response for user with permissions', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for user with permissions', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -3553,26 +3540,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom user id field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom user id field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -3580,26 +3567,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom entity user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom entity user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, request, cb) {
-							cb(null, {creator: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {creator: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -3611,12 +3598,12 @@ describe('hapi-authorization', function() {
 
 	});
 
-	describe('Initialize with roles, hierarchy, and roleHierarchy', function() {
+	describe('Initialize with roles, hierarchy, and roleHierarchy', () => {
 
-		var plugin = {
+		const plugin = {
 			name: 'hapiAuthorization',
 			version: '0.0.0',
-			register: Plugin.register,
+			plugin: Plugin.plugin,
 			path: libpath,
 			options: {
 				roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3625,22 +3612,22 @@ describe('hapi-authorization', function() {
 			}
 		};
 
-		describe('ACL roles', function() {
+		describe('ACL roles', () => {
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'USER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3648,20 +3635,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with an invalid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with an invalid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'ADMIN'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3669,42 +3656,41 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Restricts access to protected route for multiple authorized roles that are not defined as plugin roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Restricts access to protected route for multiple authorized roles that are not defined as plugin roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
-							//expect(res.payload).to.equal('Authorized');
-							expect(res.statusCode).to.equal(403);
-							expect(res.result.message).to.equal("Unauthorized");
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
+							expect(res.payload).to.equal('Authorized');
+							expect(res.statusCode).to.equal(200);
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -3712,20 +3698,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -3733,20 +3719,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -3754,20 +3740,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with unsuited role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with unsuited role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3775,20 +3761,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when a user with a role that is not a valid role tries to access a role protected route', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'OWNER'}},
-					handler: function (request, reply) { reply("TEST");}
+					handler: (request, h) => { return "TEST";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'KING'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -3796,20 +3782,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for a single role', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for a single role', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.payload).to.equal('Authorized');
 						}, done);
@@ -3817,40 +3803,40 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Allows access to protected method for multiple authorized roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Allows access to protected method for multiple authorized roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['EMPLOYEE', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.payload).to.equal('Authorized');
 						}, done);
 					});
 				});
 			});
 
-			it('Returns an error when a single role is not one of the allowed roles', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a single role is not one of the allowed roles', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: ['OWNER', 'MANAGER']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'EMPLOYEE'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3859,22 +3845,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3883,9 +3869,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'MANAGER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3894,22 +3880,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when a user\'s role is unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3918,9 +3904,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3929,22 +3915,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when any of a user\'s roles are unsuited due to hierarchy being disabled', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'EMPLOYEE'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
 
-				var plugin = {
+				const plugin = {
 					name: 'hapiAuthorization',
 					version: '0.0.0',
-					register: Plugin.register,
+					plugin: Plugin.plugin,
 					path: libpath,
 					options: {
 						roles: ['OWNER', 'MANAGER', 'EMPLOYEE'],
@@ -3953,9 +3939,9 @@ describe('hapi-authorization', function() {
 					}
 				};
 
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'OWNER'}}).then((res) => {
+						internals.asyncCheck(() => {
 
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
@@ -3964,20 +3950,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying role (singular) with an array', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying role (singular) with an array', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" must be a string');
 						}, done);
@@ -3985,20 +3971,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying roles (plural) with a string', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying roles (plural) with a string', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {roles: 'USER'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "roles" must be an array');
 						}, done);
@@ -4006,20 +3992,20 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('Returns an error when specifying both role and roles as options', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('Returns an error when specifying both role and roles as options', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {role: 'USER', roles: ['USER', 'ADMIN']}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.equal('Invalid route options (Invalid settings) ValidationError: "role" conflict with forbidden peer "roles"');
 						}, done);
@@ -4029,22 +4015,22 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('fetchEntity', function() {
+		describe('fetchEntity', () => {
 
-			it('validates that the aclQuery parameter is a function', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('validates that the aclQuery parameter is a function', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {aclQuery: 'not function'}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400)
 							expect(res.result.message).to.match(/"aclQuery" must be a Function/);
 						}, done);
@@ -4052,22 +4038,22 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('fetches the wanted entity using the query', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('fetches the wanted entity using the query', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, {id: '1', name: 'Asaf'});
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return {id: '1', name: 'Asaf'};
 					}}},
-					handler: function (request, reply) { reply(request.plugins.hapiAuthorization.entity);}
+					handler: (request, h) => { return request.plugins.hapiAuthorization.entity;}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Asaf');
 						}, done);
@@ -4075,44 +4061,44 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles not found entities', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles not found entities', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(null, null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						return null;
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('handles query errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles query errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
-					plugins: {'hapiAuthorization': {aclQuery: function(id, request, cb) {
-						cb(new Error("Boomy"), null);
+					plugins: {'hapiAuthorization': {aclQuery: (id, request) => {
+						throw new Error("Boomy");
 					}}},
-					handler: function (request, reply) { reply("Oops");}
+					handler: (request, h) => { return "Oops";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 						}, done);
 					});
@@ -4120,22 +4106,22 @@ describe('hapi-authorization', function() {
 			});
 		});
 
-		describe('validateEntityAcl', function() {
+		describe('validateEntityAcl', () => {
 
-			it('requires aclQuery when validateEntityAcl is true', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('requires aclQuery when validateEntityAcl is true', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {validateEntityAcl: true}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(400);
 							expect(res.result.message).to.match(/"aclQuery" is required/);
 						}, done);
@@ -4143,105 +4129,105 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns an error when the entity was not found', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns an error when the entity was not found', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, null);
+						aclQuery: (id, request) => {
+							return null;
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(404);
 						}, done);
 					});
 				});
 			});
 
-			it('declines requests from unauthorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('declines requests from unauthorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, false)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return false; }};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 						}, done);
 					});
 				});
 			});
 
-			it('handles validator errors', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles validator errors', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(new Error('Boom'))}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { throw new Error('Boom')}};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(500);
 						}, done);
 					});
 				});
 			});
 
-			it('returns the response for authorized users', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for authorized users', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						validateAclMethod: 'isGranted',
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello', isGranted: function(user, role, cb) {cb(null, true)}});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello', isGranted: (user, role) => { return true; }};
 						}
 					}},
-					handler: function (request, reply) {
-						reply(request.plugins.hapiAuthorization.entity);
+					handler: (request, h) => {
+						return request.plugins.hapiAuthorization.entity;
 					}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result.name).to.equal('Hello');
 						}, done);
@@ -4251,27 +4237,27 @@ describe('hapi-authorization', function() {
 
 		});
 
-		describe('default acl validator', function() {
+		describe('default acl validator', () => {
 
-			it('returns error when the entity has no user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity has no user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {id: id, name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {id: id, name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -4279,25 +4265,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns error when the entity doesn\'t belong to the authenticated user', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns error when the entity doesn\'t belong to the authenticated user', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '2'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(403);
 							expect(res.result.message).to.equal("Unauthorized");
 						}, done);
@@ -4305,25 +4291,25 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('returns the response for user with permissions', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('returns the response for user with permissions', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -4331,26 +4317,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom user id field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom user id field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						userIdField: 'myId',
-						aclQuery: function(id, request, cb) {
-							cb(null, {_user: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {_user: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', myId: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -4358,26 +4344,26 @@ describe('hapi-authorization', function() {
 				});
 			});
 
-			it('handles custom entity user field', function(done) {
-				var server = new Hapi.Server();
-				server.connection();
+			it('handles custom entity user field', (done) => {
+				const server = new Hapi.Server();
+				
 				server.auth.scheme('custom', internals.authSchema);
-				server.auth.strategy('default', 'custom', true, {});
+				server.auth.strategy('default', 'custom', {});
 
-				server.route({ method: 'GET', path: '/', config: {
+				server.route({ method: 'GET', path: '/', options: {
 					auth: 'default',
 					plugins: {'hapiAuthorization': {
 						validateEntityAcl: true,
 						entityUserField: 'creator',
-						aclQuery: function(id, request, cb) {
-							cb(null, {creator: '1', name: 'Hello'});
+						aclQuery: (id, request) => {
+							return {creator: '1', name: 'Hello'};
 						}
 					}},
-					handler: function (request, reply) { reply("Authorized");}
+					handler: (request, h) => { return "Authorized";}
 				}});
-				server.register(plugin, {}, function(err) {
-					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}, function(res) {
-						internals.asyncCheck(function() {
+				server.register(plugin, {}).then(() => {
+					server.inject({method: 'GET', url: '/', credentials: {role: 'ADMIN', _id: '1'}}).then((res) => {
+						internals.asyncCheck(() => {
 							expect(res.statusCode).to.equal(200);
 							expect(res.result).to.equal("Authorized");
 						}, done);
@@ -4390,24 +4376,24 @@ describe('hapi-authorization', function() {
 	});
 });
 
-internals.authSchema = function() {
+internals.authSchema = () => {
 
-	var scheme = {
-		authenticate: function (request, reply) {
-			return reply({ username: "asafdav", role: 'USER'});
+	const scheme = {
+		authenticate: (request, h) => {
+			return { username: "asafdav", role: 'USER'};
 		},
-		payload: function (request, reply) {
-			return reply(request.auth.credentials.payload);
+		payload: (request, h) => {
+			return request.auth.credentials.payload;
 		},
-		response: function (request, reply) {
-			return reply();
+		response: (request, h) => {
+			return {};
 		}
 	};
 
 	return scheme;
 };
 
-internals.asyncCheck = function(f, done) {
+internals.asyncCheck = (f, done) => {
 	try {
 		f();
 		done();

--- a/test/index.js
+++ b/test/index.js
@@ -17,25 +17,30 @@ describe('hapi-authorization', function() {
 	var plugin = {
 		name: 'hapiAuthorization',
 		version: '0.0.0',
-		register: Plugin.plugin.register,
+		plugin: Plugin.plugin,
 		path: libpath
 	};
 
-	it('does not interfere with handlers throwing exceptions', function(done) {
+	it('does not interfere with handlers throwing exceptions', async (done) => {
 		var server = new Hapi.Server();
 		server.route({ method: 'GET', path: '/', config: {
 			handler: function (request, reply) {throw new Error("uncaught exception test");}
 		}});
-		server.register(plugin, {}, function(err) {
-			server.start(function(err) {
-				server.inject({method: 'GET', url: '/'}, function(res) {
-					internals.asyncCheck(function() {
-						expect(res.statusCode).to.equal(500);
-						server.stop(NOOP);
-					}, done);
-				});
-			});
-		});
+    console.log('zero')
+    await server.register(plugin, {});
+    
+    console.log(1)
+    server.start(function(err) {
+      console.log(2)
+      server.inject({method: 'GET', url: '/'}, function(res) {
+        console.log(3)
+        internals.asyncCheck(function() {
+          console.log(4)
+          expect(res.statusCode).to.equal(500);
+          server.stop(NOOP);
+        }, done);
+      });
+    });
 	});
 
 	it('makes sure that hapi-authorization can be enabled only for secured routes', function(done) {

--- a/test/index.js
+++ b/test/index.js
@@ -17,13 +17,12 @@ describe('hapi-authorization', function() {
 	var plugin = {
 		name: 'hapiAuthorization',
 		version: '0.0.0',
-		register: Plugin.register,
+		register: Plugin.plugin.register,
 		path: libpath
 	};
 
 	it('does not interfere with handlers throwing exceptions', function(done) {
 		var server = new Hapi.Server();
-		server.connection();
 		server.route({ method: 'GET', path: '/', config: {
 			handler: function (request, reply) {throw new Error("uncaught exception test");}
 		}});
@@ -40,8 +39,7 @@ describe('hapi-authorization', function() {
 	});
 
 	it('makes sure that hapi-authorization can be enabled only for secured routes', function(done) {
-		var server = new Hapi.Server(0);
-		server.connection();
+		var server = new Hapi.Server();
 		server.route({ method: 'GET', path: '/', config: {
 			plugins: {'hapiAuthorization': {role: 'USER'}},
 			handler: function (request, reply) { reply("TEST");}


### PR DESCRIPTION
- upgrade nodejs version on travis CI (`Version 17.x only supports node v8.9.0 and over. `)
- move from `var` to `let`/ `const`
- move to new `register` syntax for plugins
- remove `q`  to use native promise
- update documentation with new plugin syntax
- upgrade to major version 4
- [forwards `roles` to `aclQuery` if `role` is undefined](https://github.com/toymachiner62/hapi-authorization/pull/25/files#diff-6d186b954a58d5bb740f73d84fe39073R141)

Thx @maxaus for his contribution.

I recommend having more people testing it.
just modify your `package.json` from
`"hapi-authorization": "^3.0.2",`
to
`"hapi-authorization": "mycshq/hapi-authorization#hapi-17",`
and run `npm i`