### PR TITLE
Fix bonded config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ internals.validateRoutes = (server) => {
  * @param request
  * @param h Hapi Reponse Toolkit https://hapijs.com/api#response-toolkit
  */
-internals.onPreHandler = async (request, h) => {
+internals.onPreHandler = async function (request, h) {
 
   // Ignore OPTIONS requests
   if (request.route.method === 'options') {


### PR DESCRIPTION
Removing the arrow function definition, the bonded config can be easily accessed as before (`this.config`).

Close #26